### PR TITLE
Presentation/theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,20 @@ We would endlessly like to thank the following contributors
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/GibsonRuitiari">
+            <img src="https://avatars.githubusercontent.com/u/88240355?v=4" width="100;" alt="GibsonRuitiari"/>
+            <br />
+            <sub><b>8BitsLives .❤️</b></sub>
+        </a>
+    </td></tr>
+<tr>
+    <td align="center">
         <a href="https://github.com/michaelbukachi">
             <img src="https://avatars.githubusercontent.com/u/10145850?v=4" width="100;" alt="michaelbukachi"/>
             <br />
             <sub><b>Michael Bukachi</b></sub>
         </a>
-    </td></tr>
-<tr>
+    </td>
     <td align="center">
         <a href="https://github.com/keithchad">
             <img src="https://avatars.githubusercontent.com/u/63049827?v=4" width="100;" alt="keithchad"/>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("io.gitlab.arturbosch.detekt") version "1.18.0-RC2"
     id("com.diffplug.spotless") version "6.0.0"
-    id("org.jetbrains.dokka") version "1.4.20"
+    id("org.jetbrains.dokka") version "1.7.10"
     kotlin("plugin.serialization") version "1.6.21"
 }
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -7,3 +7,4 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compose = "1.3.0-alpha01"
 composecompiler = "1.2.0"
 coroutines = "1.6.0"
-espresso = "3.4.0"
+espresso = "3.5.0-alpha07"
 gradleplugin = "7.1.3"
 hilt = "2.42"
 kotlin = "1.6.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,13 +2,14 @@
 compose = "1.3.0-alpha01"
 composecompiler = "1.2.0"
 coroutines = "1.6.0"
-espresso = "3.5.0-alpha07"
+espresso = "3.4.0"
 gradleplugin = "7.1.3"
 hilt = "2.42"
 kotlin = "1.6.10"
 lifecycle = "2.5.0"
 room = "2.4.2"
 ktor = "2.0.3"
+
 splash = "1.0.0-rc01"
 
 [libraries]
@@ -24,7 +25,7 @@ android-test-compose = { module = "androidx.compose.ui:ui-test-junit4", version.
 android-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 android-test-idling = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "espresso" }
 android-test-junit4 = "androidx.test.ext:junit:1.1.3"
-android-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splash" }
+androidx-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splash" }
 coil-compose = "io.coil-kt:coil-compose:2.0.0-rc03"
 compose-activity = "androidx.activity:activity-compose:1.5.0"
 compose-compiler = "androidx.compose.compiler:compiler:1.2.0"

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     testImplementation(libs.test.robolectric)
     testImplementation(libs.compose.ui.test.junit)
     testImplementation(libs.android.test.espresso)
-
 }
 
 kotlin {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation(libs.lifecycle.runtimeKtx)
     implementation(libs.timber)
     implementation(libs.android.hilt)
-    implementation(libs.android.splashscreen)
+    implementation(libs.androidx.splashscreen)
     kapt(libs.android.hilt.compiler)
     implementation(libs.android.hilt.compose)
     kapt(libs.android.hilt.androidx.compiler)

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -111,10 +111,8 @@ fun DroidconKE2022Theme(
             val activity = view.context.findActivity()
             // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
             // closest activity in the given context thus making this method [not that] lack of a better word safe
-            //see https://gist.github.com/GibsonRuitiari/7cb947228661993ee36d5c05b9e8f23f
+            //see https://gist.github.com/GibsonRuitiari/7cb947228661993ee36d5c05b9e8f23f for a detailed explanat
             activity.window.statusBarColor = colorScheme.primary.toArgb()
-            // Using this method might return if the function fails to find window associated with the given activity's context
-            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
             WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = darkTheme
         }
     }

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 
 private val LightColors = lightColorScheme(
@@ -109,14 +108,14 @@ fun DroidconKE2022Theme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val activity=view.context.findActivity()
-             // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
-             //closest activity in the given context thus making this method [not that] lack of a better word safe
+            val activity = view.context.findActivity()
+            // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
+            // closest activity in the given context thus making this method [not that] lack of a better word safe
             // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
             activity.window.statusBarColor = colorScheme.primary.toArgb()
-            //Using this method might return if the function fails to find window associated with the given activity's context
-            //ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme */
-            WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars =darkTheme
+            // Using this method might return if the function fails to find window associated with the given activity's context
+            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme */
+            WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
 
@@ -131,9 +130,9 @@ fun DroidconKE2022Theme(
  * Iterate through the context wrapper to find the closest
  * activity associated with this context
  */
-private fun Context.findActivity():Activity{
-    var context =this
-    while (context is ContextWrapper){
+private fun Context.findActivity(): Activity {
+    var context = this
+    while (context is ContextWrapper) {
         if (context is Activity) return context
         context = context.baseContext
     }

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -109,9 +109,6 @@ fun DroidconKE2022Theme(
     if (!view.isInEditMode) {
         SideEffect {
             val activity = view.context.findActivity()
-            // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
-            // closest activity in the given context thus making this method [not that] lack of a better word safe
-            //see https://gist.github.com/GibsonRuitiari/7cb947228661993ee36d5c05b9e8f23f for a detailed explanat
             activity.window.statusBarColor = colorScheme.primary.toArgb()
             WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = darkTheme
         }
@@ -125,9 +122,11 @@ fun DroidconKE2022Theme(
 }
 
 /**
- * Iterate through the context wrapper to find the closest
- * activity associated with this context
+ * Iterate through the context wrapper to find the closest activity associated with this context
+ * This method is preferred to LocalContext.current as Activity
+ * see [Theme.md](https://gist.github.com/GibsonRuitiari/7cb947228661993ee36d5c05b9e8f23f)
  * Throws [IllegalStateException] if no activity was found
+ * @return an activity instance
  */
 private fun Context.findActivity(): Activity {
     var context = this

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -111,7 +111,7 @@ fun DroidconKE2022Theme(
             val activity = view.context.findActivity()
             // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
             // closest activity in the given context thus making this method [not that] lack of a better word safe
-            // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
+            //see https://gist.github.com/GibsonRuitiari/7cb947228661993ee36d5c05b9e8f23f
             activity.window.statusBarColor = colorScheme.primary.toArgb()
             // Using this method might return if the function fails to find window associated with the given activity's context
             // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -16,6 +16,8 @@
 package com.android254.presentation.common.theme
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +31,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 
 private val LightColors = lightColorScheme(
     primary = md_theme_light_primary,
@@ -106,8 +109,16 @@ fun DroidconKE2022Theme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
-            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
+            val activity=view.context.findActivity()
+            // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
+            //closest activity in the given context thus making this method [not that] lack of a better word safe
+           // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
+            activity.window.statusBarColor = colorScheme.primary.toArgb()
+            /* Using this method might return if the function fails to find window associated with the given activity's context
+            */
+            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
+            // safer
+            WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars =darkTheme
         }
     }
 
@@ -116,4 +127,17 @@ fun DroidconKE2022Theme(
         typography = AppTypography,
         content = content
     )
+}
+
+/**
+ * Iterate through the context wrapper to find the closest
+ * activity associated with this context
+ */
+private fun Context.findActivity():Activity{
+    var context =this
+    while (context is ContextWrapper){
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    throw IllegalStateException("Activity absent")
 }

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -110,14 +110,12 @@ fun DroidconKE2022Theme(
     if (!view.isInEditMode) {
         SideEffect {
             val activity=view.context.findActivity()
-            // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
-            //closest activity in the given context thus making this method [not that] lack of a better word safe
-           // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
+             // although view.context in compose is gotten from LocalContext.current the fetched context might not be the
+             //closest activity in the given context thus making this method [not that] lack of a better word safe
+            // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
             activity.window.statusBarColor = colorScheme.primary.toArgb()
-            /* Using this method might return if the function fails to find window associated with the given activity's context
-            */
-            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
-            // safer
+            //Using this method might return if the function fails to find window associated with the given activity's context
+            //ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme */
             WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars =darkTheme
         }
     }

--- a/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
+++ b/presentation/src/main/java/com/android254/presentation/common/theme/Theme.kt
@@ -114,7 +114,7 @@ fun DroidconKE2022Theme(
             // (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
             activity.window.statusBarColor = colorScheme.primary.toArgb()
             // Using this method might return if the function fails to find window associated with the given activity's context
-            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme */
+            // ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme
             WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
@@ -129,6 +129,7 @@ fun DroidconKE2022Theme(
 /**
  * Iterate through the context wrapper to find the closest
  * activity associated with this context
+ * Throws [IllegalStateException] if no activity was found
  */
 private fun Context.findActivity(): Activity {
     var context = this


### PR DESCRIPTION
# Scope

_Please make sure to read https://github.com/droidconKE/droidconKE2022Android/docs/CONTRIBUTING.md
and check that you understand and have followed it as best as possible .
_Description of changes_
I have edited the Theme.kt file in Presentation module by adding a convenient method of getting activity when given a context
instead of casting view.context as Activity as previously done before. The method iterates through the context wrapper and finds the closest activity associated with the Context and returns that activity. In this way, it is much safer than using
view.context as Activity.

I have also changed the line ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = darkTheme to
  WindowCompat.getInsetsController(activity.window, view).isAppearanceLightStatusBars = darkTheme.
 
Using the previous method ViewCompat.getWindowInsetsController() without specifying the window  might return a null WindowInsetsController if the function fails to find window associated with the given activity's context. On the other hand, the latter method
WindowCompat.getInsetsController() uses a window so there's an assurance that a windowInsetsController will always be returned (hence null safe).

_ please check the below boxes_
- [X] I have followed the coding conventions
- [ ] I have added/updated necessary tests
- [X] I have tested the changes added on a physical device

## Closes/Fixes Issues
_Declare any issues by typing `fixes #1` or `closes #1` for example so that the automation can kick
in when this is merged_

