### PR TITLE
Added Preference Datastore :gear:

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.android.hilt)
     implementation(libs.timber)
     kapt(libs.android.hilt.compiler)
+    implementation(libs.datastore)
     implementation(libs.room.runtime)
     ksp(libs.room.compiler)
     implementation(libs.room.ktx)

--- a/data/src/main/java/com/android254/data/di/DatastoreModule.kt
+++ b/data/src/main/java/com/android254/data/di/DatastoreModule.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+private const val DCNBO22_PREFERENCES = "dcke22-pref"
+
+@InstallIn(SingletonComponent::class)
+@Module
+object DatastoreModule {
+
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            migrations = listOf(SharedPreferencesMigration(appContext, DCNBO22_PREFERENCES)),
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            produceFile = { appContext.preferencesDataStoreFile(DCNBO22_PREFERENCES) }
+        )
+    }
+}

--- a/data/src/main/java/com/android254/data/di/DatastoreModule.kt
+++ b/data/src/main/java/com/android254/data/di/DatastoreModule.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
-private const val DCNBO22_PREFERENCES = "dcke22-pref"
+private const val DCKE22_PREFERENCES = "dcke22-pref"
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -46,9 +46,9 @@ object DatastoreModule {
             corruptionHandler = ReplaceFileCorruptionHandler(
                 produceNewData = { emptyPreferences() }
             ),
-            migrations = listOf(SharedPreferencesMigration(appContext, DCNBO22_PREFERENCES)),
+            migrations = listOf(SharedPreferencesMigration(appContext, DCKE22_PREFERENCES)),
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
-            produceFile = { appContext.preferencesDataStoreFile(DCNBO22_PREFERENCES) }
+            produceFile = { appContext.preferencesDataStoreFile(DCKE22_PREFERENCES) }
         )
     }
 }

--- a/data/src/main/java/com/android254/data/network/util/TokenProvider.kt
+++ b/data/src/main/java/com/android254/data/network/util/TokenProvider.kt
@@ -19,17 +19,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface TokenProvider {
 
-    fun fetch(): Flow<String>
+    suspend fun fetch(): Flow<String?>
 
-    fun update(): Flow<String>
-}
-
-class DefaultTokenProvider : TokenProvider {
-    override fun fetch(): Flow<String> {
-        TODO("Not yet implemented")
-    }
-
-    override fun update(): Flow<String> {
-        TODO("Not yet implemented")
-    }
+    suspend fun update(accessToken: String)
 }

--- a/data/src/main/java/com/android254/data/preferences/DefaultTokenProvider.kt
+++ b/data/src/main/java/com/android254/data/preferences/DefaultTokenProvider.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.data.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.android254.data.network.util.TokenProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+
+private object PreferencesKeys {
+    val ACCESS_TOKEN = stringPreferencesKey("access_token")
+}
+
+class DefaultTokenProvider @Inject constructor(private val dataStore: DataStore<Preferences>) :
+    TokenProvider {
+
+    override suspend fun fetch(): Flow<String?> = dataStore.data
+        .catch { exception ->
+            // dataStore.data throws an IOException when an error is encountered when reading data
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }.map { preferences ->
+            preferences[PreferencesKeys.ACCESS_TOKEN]
+        }
+
+    override suspend fun update(accessToken: String) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.ACCESS_TOKEN] = accessToken
+        }
+    }
+}

--- a/data/src/main/java/com/android254/data/preferences/DefaultTokenProvider.kt
+++ b/data/src/main/java/com/android254/data/preferences/DefaultTokenProvider.kt
@@ -24,7 +24,6 @@ import com.android254.data.network.util.TokenProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
-import java.io.IOException
 import javax.inject.Inject
 
 private object PreferencesKeys {
@@ -35,13 +34,8 @@ class DefaultTokenProvider @Inject constructor(private val dataStore: DataStore<
     TokenProvider {
 
     override suspend fun fetch(): Flow<String?> = dataStore.data
-        .catch { exception ->
-            // dataStore.data throws an IOException when an error is encountered when reading data
-            if (exception is IOException) {
-                emit(emptyPreferences())
-            } else {
-                throw exception
-            }
+        .catch {
+            emit(emptyPreferences())
         }.map { preferences ->
             preferences[PreferencesKeys.ACCESS_TOKEN]
         }

--- a/data/src/test/java/com/android254/data/network/AuthApiTest.kt
+++ b/data/src/test/java/com/android254/data/network/AuthApiTest.kt
@@ -13,25 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android254.data.dao.network
+package com.android254.data.network
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
 import com.android254.data.network.apis.AuthApi
 import com.android254.data.network.models.payloads.GoogleToken
 import com.android254.data.network.models.responses.AccessToken
 import com.android254.data.network.models.responses.Status
 import com.android254.data.network.models.responses.UserDetails
-import com.android254.data.network.util.DefaultTokenProvider
 import com.android254.data.network.util.HttpClientFactory
 import com.android254.data.network.util.ServerError
+import com.android254.data.preferences.DefaultTokenProvider
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class AuthApiTest {
+
+    private lateinit var testDataStore: DataStore<Preferences>
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        testDataStore = PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("test") }
+        )
+    }
 
     @Test(expected = ServerError::class)
     fun `test ServerError is thrown when a server exception occurs`() {
@@ -39,7 +59,7 @@ class AuthApiTest {
             delay(500)
             respondError(HttpStatusCode.InternalServerError)
         }
-        val httpClient = HttpClientFactory(DefaultTokenProvider()).create(mockEngine)
+        val httpClient = HttpClientFactory(DefaultTokenProvider(testDataStore)).create(mockEngine)
         val api = AuthApi(httpClient)
         runBlocking {
             api.logout()
@@ -55,7 +75,7 @@ class AuthApiTest {
                 headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
-        val httpClient = HttpClientFactory(DefaultTokenProvider()).create(mockEngine)
+        val httpClient = HttpClientFactory(DefaultTokenProvider(testDataStore)).create(mockEngine)
         val api = AuthApi(httpClient)
         runBlocking {
             val response = api.logout()
@@ -84,7 +104,7 @@ class AuthApiTest {
                 headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
-        val httpClient = HttpClientFactory(DefaultTokenProvider()).create(mockEngine)
+        val httpClient = HttpClientFactory(DefaultTokenProvider(testDataStore)).create(mockEngine)
         val api = AuthApi(httpClient)
         runBlocking {
             val accessToken = AccessToken(

--- a/data/src/test/java/com/android254/data/preferences/DefaultTokenProviderTest.kt
+++ b/data/src/test/java/com/android254/data/preferences/DefaultTokenProviderTest.kt
@@ -1,0 +1,42 @@
+package com.android254.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DefaultTokenProviderTest {
+
+    private lateinit var testDataStore: DataStore<Preferences>
+    private lateinit var tokenProvider: DefaultTokenProvider
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        testDataStore = PreferenceDataStoreFactory.create(
+            produceFile = { context.preferencesDataStoreFile("test") }
+        )
+        tokenProvider = DefaultTokenProvider(testDataStore)
+    }
+
+    @Test
+    fun `test successful token update and fetch`() {
+        runBlocking {
+            tokenProvider.update("some_random_token_here")
+            val response = tokenProvider.fetch().firstOrNull()
+            assertThat(response, CoreMatchers.`is`("some_random_token_here"))
+        }
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-paging = { module = "androidx.room:room-paging", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+datastore = "androidx.datastore:datastore-preferences:1.0.0"
 timber = "com.jakewharton.timber:timber:5.0.1"
 test-junit4 = "junit:junit:4.13.2"
 test-androidx-core = "androidx.test:core-ktx:1.4.0"

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     testImplementation(libs.test.robolectric)
     testImplementation(libs.compose.ui.test.junit)
     testImplementation(libs.android.test.espresso)
-
 }
 
 kotlin {

--- a/presentation/src/main/java/com/android254/presentation/models/SessionPresentationModel.kt
+++ b/presentation/src/main/java/com/android254/presentation/models/SessionPresentationModel.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.models
 
 data class SessionPresentationModel(

--- a/presentation/src/test/java/com/android254/presentation/about/view/AboutScreenTest.kt
+++ b/presentation/src/test/java/com/android254/presentation/about/view/AboutScreenTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.android254.presentation.about.view
 
 import androidx.compose.ui.test.assertIsDisplayed


### PR DESCRIPTION
# Scope

This PR adds the `Preference Datastore`, and refactors the `TokenProvider` to `update` and `fetch` the `access_token` when needed by emitting a `Flow<String>`

- [x] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device

## Closes/Fixes Issues
Not attached to any issue 

## Other testing QA Notes
can be tested by inserting and querying the `access_token` 

Please add a screenshot (if necessary)
