### PR TITLE
Bug: Replace `kapt` with `ksp` for room

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -19,10 +19,8 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
-    kapt {
-        arguments {
-            arg("room.schemaLocation", "$projectDir/schemas")
-        }
+    ksp {
+        arg("room.schemaLocation", "$projectDir/schemas")
     }
 
     testOptions {


### PR DESCRIPTION
# Scope

Swap `kapt` with `ksp` for annotations

- [x] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device

## Closes/Fixes Issues
N/A

## Other testing QA Notes
N/A

Please add a screenshot (if necessary)
