### PR TITLE
[Domain] Create GetSpeakers use case

### DIFF
--- a/data/src/test/java/com/android254/data/network/SpeakerRemoteSourceTest.kt
+++ b/data/src/test/java/com/android254/data/network/SpeakerRemoteSourceTest.kt
@@ -66,6 +66,7 @@ class SpeakerRemoteSourceTest {
                 shortBio = "Cool guy",
                 bio = "Very cool guy",
                 avatar = "https://example.com",
+                session = "session_id_1",
                 twitter = null
             ),
         )

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -7,3 +7,18 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 }
+
+dependencies {
+    testImplementation(libs.test.junit4)
+    testImplementation(libs.kotlin.coroutines.test)
+}
+
+kotlin {
+    sourceSets {
+        all {
+            languageSettings.apply {
+                optIn("kotlinx.coroutines.ExperimentalCoroutinesApi")
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/android254/domain/models/SpeakerDomainModel.kt
+++ b/domain/src/main/java/com/android254/domain/models/SpeakerDomainModel.kt
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android254.data.network.models.responses
+package com.android254.domain.models
 
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class SpeakerApiModel(
+data class SpeakerDomainModel(
     val id: String,
     val name: String,
     val bio: String,

--- a/domain/src/main/java/com/android254/domain/repos/SpeakerRepository.kt
+++ b/domain/src/main/java/com/android254/domain/repos/SpeakerRepository.kt
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android254.data.network.models.responses
+package com.android254.domain.repos
 
-import kotlinx.serialization.Serializable
+import com.android254.domain.models.DataResult
+import com.android254.domain.models.SpeakerDomainModel
 
-@Serializable
-data class SpeakerApiModel(
-    val id: String,
-    val name: String,
-    val bio: String,
-    val shortBio: String,
-    val avatar: String,
-    val session: String,
-    val twitter: String?
-)
+interface SpeakerRepository {
+    suspend fun getSpeakers(): DataResult<List<SpeakerDomainModel>>
+}

--- a/domain/src/main/java/com/android254/domain/usecases/GetSpeakersUseCase.kt
+++ b/domain/src/main/java/com/android254/domain/usecases/GetSpeakersUseCase.kt
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android254.data.network.models.responses
+package com.android254.domain.usecases
 
-import kotlinx.serialization.Serializable
+import com.android254.domain.models.DataResult
+import com.android254.domain.models.SpeakerDomainModel
+import com.android254.domain.repos.SpeakerRepository
 
-@Serializable
-data class SpeakerApiModel(
-    val id: String,
-    val name: String,
-    val bio: String,
-    val shortBio: String,
-    val avatar: String,
-    val session: String,
-    val twitter: String?
-)
+class GetSpeakersUseCase(
+    private val speakerRepository: SpeakerRepository
+) {
+    suspend operator fun invoke(): DataResult<List<SpeakerDomainModel>> =
+        speakerRepository.getSpeakers()
+}

--- a/domain/src/test/java/com/android254/domain/usecases/GetSpeakersUseCaseTest.kt
+++ b/domain/src/test/java/com/android254/domain/usecases/GetSpeakersUseCaseTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.domain.usecases
+
+import com.android254.domain.models.DataResult
+import com.android254.domain.models.SpeakerDomainModel
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class GetSpeakersUseCaseTest {
+    @Test
+    fun `returns speakers data as received from the speaker repository`() = runTest {
+        val expectedSpeakers = listOf(
+            SpeakerDomainModel(
+                id = "1",
+                name = "John Doe",
+                shortBio = "Kotlin GDE",
+                bio = "I love contributing to OS",
+                avatar = "https://example.com",
+                session = "session_id_1",
+                twitter = null
+            )
+        )
+        val getSpeakers = GetSpeakersUseCase(
+            MockSpeakerRepository(speakers = expectedSpeakers)
+        )
+
+        assertThat(getSpeakers(), `is`(DataResult.Success(expectedSpeakers)))
+    }
+}

--- a/domain/src/test/java/com/android254/domain/usecases/MockSpeakerRepository.kt
+++ b/domain/src/test/java/com/android254/domain/usecases/MockSpeakerRepository.kt
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android254.data.network.models.responses
+package com.android254.domain.usecases
 
-import kotlinx.serialization.Serializable
+import com.android254.domain.models.DataResult
+import com.android254.domain.models.SpeakerDomainModel
+import com.android254.domain.repos.SpeakerRepository
 
-@Serializable
-data class SpeakerApiModel(
-    val id: String,
-    val name: String,
-    val bio: String,
-    val shortBio: String,
-    val avatar: String,
-    val session: String,
-    val twitter: String?
-)
+class MockSpeakerRepository(
+    private val speakers: List<SpeakerDomainModel> = emptyList(),
+) : SpeakerRepository {
+    override suspend fun getSpeakers(): DataResult<List<SpeakerDomainModel>> =
+        DataResult.Success(speakers)
+}


### PR DESCRIPTION
# Scope
Add `GetSpeakersUseCase`

Merely reads and returns the data from `SpeakerRepository` for now.
I have tried to guess the properties of `SpeakerDomainModel` from the UI designs of the _single speaker_ and _speakers list_ screens.
I have also made a tiny change to the data layer to make the speaker model there compatible with the speaker model in the domain layer.

- [x] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [x] I have tested the changes added on a physical device
