### PR TITLE
[Data] Fetch feed from API

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -40,6 +40,8 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }

--- a/data/src/main/java/com/android254/data/network/apis/FeedApi.kt
+++ b/data/src/main/java/com/android254/data/network/apis/FeedApi.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.data.network.apis
+
+import com.android254.data.network.Constants
+import com.android254.data.network.models.responses.Feed
+import com.android254.data.network.models.responses.PaginatedResponse
+import com.android254.data.network.util.dataResultSafeApiCall
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import javax.inject.Inject
+
+class FeedApi @Inject constructor(private val client: HttpClient) {
+
+    suspend fun fetchFeed(page: Int = 1, size: Int = 100) = dataResultSafeApiCall {
+        val response: PaginatedResponse<List<Feed>> =
+            client.get("${Constants.EVENT_BASE_URL}/feeds") {
+                url {
+                    parameters.append("page", page.toString())
+                    parameters.append("per_page", size.toString())
+                }
+            }.body()
+
+        return@dataResultSafeApiCall response.data
+    }
+}

--- a/data/src/main/java/com/android254/data/network/models/responses/Feed.kt
+++ b/data/src/main/java/com/android254/data/network/models/responses/Feed.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.data.network.models.responses
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Serializable
+data class Feed(
+    val title: String,
+    val body: String,
+    val topic: String,
+    val url: String,
+    val image: String?,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    @SerialName("created_at")
+    val createdAt: LocalDateTime
+)
+
+private class LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+
+    private val formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss")
+
+    override fun serialize(encoder: Encoder, value: LocalDateTime) {
+        encoder.encodeString(value.format(formatter))
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDateTime =
+        LocalDateTime.parse(decoder.decodeString(), formatter)
+}

--- a/data/src/test/java/com/android254/data/network/FeedApiTest.kt
+++ b/data/src/test/java/com/android254/data/network/FeedApiTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 DroidconKE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android254.data.network
+
+import com.android254.data.network.models.responses.Feed
+import com.android254.data.network.apis.FeedApi
+import com.android254.data.network.util.HttpClientFactory
+import com.android254.domain.models.DataResult
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class FeedApiTest {
+    @Test
+    fun `sends correct http request`() = runTest {
+        val mockEngine = MockEngine { respondOk() }
+        val httpClient = HttpClientFactory(MockTokenProvider()).create(mockEngine)
+
+        FeedApi(httpClient).fetchFeed(page = 2, size = 50)
+
+        assertThat(mockEngine.requestHistory.size, `is`(1))
+        mockEngine.requestHistory.first().run {
+            val expectedUrl = "${Constants.EVENT_BASE_URL}/feeds?page=2&per_page=50"
+            assertThat(url.toString(), `is`(expectedUrl))
+            assertThat(method, `is`(HttpMethod.Get))
+        }
+    }
+
+    @Test
+    fun `when successful returns a list of feed items`() = runTest {
+        val httpClient = HttpClientFactory(MockTokenProvider()).create(
+            MockEngine {
+                respond(
+                    content = """{
+                        "data": [
+                            {
+                              "title": "Test",
+                              "body": "Good one",
+                              "topic": "droidconweb",
+                              "url": "https://droidcon.co.ke",
+                              "image": "http://localhost:8000/upload/event/feeds/dangyntvmaet8jgjpg.jpg",
+                              "created_at": "2020-03-19 18:45:49"
+                            },
+                            {
+                              "title": "niko fine",
+                              "body": "this is a test",
+                              "topic": "droidconweb",
+                              "url": "https://droidcon.co.ke",
+                              "image": null,
+                              "created_at": "2020-03-19 18:43:38"
+                            }
+                        ],
+                        "meta": {
+                            "paginator": {
+                              "count": 2,
+                              "per_page": "10",
+                              "current_page": 1,
+                              "next_page": null,
+                              "has_more_pages": false,
+                              "next_page_url": null,
+                              "previous_page_url": null
+                            }
+                        }
+                    }
+                    """.trimIndent(),
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }
+        )
+
+        val feed = FeedApi(httpClient).fetchFeed()
+
+        assertThat(
+            feed,
+            `is`(
+                DataResult.Success(
+                    listOf(
+                        Feed(
+                            title = "Test",
+                            body = "Good one",
+                            topic = "droidconweb",
+                            url = "https://droidcon.co.ke",
+                            image = "http://localhost:8000/upload/event/feeds/dangyntvmaet8jgjpg.jpg",
+                            createdAt = LocalDateTime.of(
+                                LocalDate.parse("2020-03-19"),
+                                LocalTime.parse("18:45:49")
+                            )
+                        ),
+                        Feed(
+                            title = "niko fine",
+                            body = "this is a test",
+                            topic = "droidconweb",
+                            url = "https://droidcon.co.ke",
+                            image = null,
+                            createdAt = LocalDateTime.of(
+                                LocalDate.parse("2020-03-19"),
+                                LocalTime.parse("18:43:38")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
# Scope
Add feed API client.

### Note
- Assumes the `created_at` field in [the API response](https://github.com/droidconKE/droidconKE2022Android/wiki/Feed-Endpoint) is in our timezone. (I suggest that it be in ISO 8601 format with time zone info)
- Added desugaring to allow using `java.time` classes

### Question
- How will paging be implemented? And is that in the scope of this task?

_Please make sure to read https://github.com/droidconKE/droidconKE2022Android/docs/CONTRIBUTING.md
and check that you understand and have followed it as best as possible Explain what your feature
does in a short paragraph._ please check the below boxes
- [ ] I have followed the coding conventions
- [x] I have added/updated necessary tests
- [ ] I have tested the changes added on a physical device
- [x] I have run `./codeAnalysis.sh` to make sure all lint/formatting checks have been done.

